### PR TITLE
Change order of association for precision

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,4 +16,4 @@ Currently, the following things are checked:
   * A line should not exceed 120 characters (this is somehow already extreme).
   * One should use `use mpi` instead of `include "mpif.h"`. Note that this is not fixed by default as it may break codes where `include "mpif.h"` follows and `implicit none` statement.
   * Spaces are preferred over tabs, trailing whitespaces are cleaned.
-  * Warnings are raised if you use `real(8) :: foo` statement as it is better to use `integer, parameter :: dp=selected_real_kind(15); real(dp) :: foo` instead or `use iso_fortran_env, only : real32=>sp, real64=>dp; real(sp) :: foo`
+  * Warnings are raised if you use `real(8) :: foo` statement as it is better to use `integer, parameter :: dp=selected_real_kind(15); real(dp) :: foo` instead or `use iso_fortran_env, only : sp=>real32, dp=>real64; real(sp) :: foo`


### PR DESCRIPTION
I think the order for the association statement given in the readme has to be flipped.